### PR TITLE
chore: remove deprecation old-deprecate-method-paths

### DIFF
--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug';
 
 import DS from 'ember-data';
 

--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug';
 
 import DS from 'ember-data';
 


### PR DESCRIPTION
 # Task
 - [x] Remove [deprecation](https://deprecations.emberjs.com/v3.x/#toc_old-deprecate-method-paths) / allow to work on Ember >= 4.0